### PR TITLE
Terminate app after window closes

### DIFF
--- a/SE Comments/ESAppDelegate.m
+++ b/SE Comments/ESAppDelegate.m
@@ -96,4 +96,7 @@
     [[NSWorkspace sharedWorkspace] openURL:[NSURL URLWithString:url]];
     
 }
+- (BOOL)applicationShouldTerminateAfterLastWindowClosed:(NSApplication *)app {
+    return YES;
+}
 @end


### PR DESCRIPTION
After the app's window is closed, the app should quit as there is no background processes that could be occurring.

Added [applicationShouldTerminateAfterLastWindowClosed](https://developer.apple.com/library/mac/documentation/Cocoa/Reference/NSApplicationDelegate_Protocol/index.html#//apple_ref/occ/intfm/NSApplicationDelegate/applicationShouldTerminateAfterLastWindowClosed:).